### PR TITLE
Add options

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,7 +86,7 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().StringVarP(&profile, "profile", "p", "", "AWS profile")
+	rootCmd.Flags().StringVarP(&profile, "profile", "p", "", "AWS named profile")
 	rootCmd.Flags().StringVarP(&duration, "duration", "d", "12hours", "the duration that the credentials should remain valid")
 	rootCmd.Flags().StringVarP(&sNum, "serial-number", "n", "", "the identification number of the MFA device")
 	rootCmd.Flags().StringVarP(&tokenCode, "token-code", "c", "", "the value provided by the MFA device")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
+var (
+	profile   string
+	duration  string
+	sNum      string
+	tokenCode string
+)
+
 var rootCmd = &cobra.Command{
 	Use:     "awsdo",
 	Short:   "AWS temporary credential (aka session token) wrapper",
@@ -41,10 +47,13 @@ var rootCmd = &cobra.Command{
 	Version: version.Version,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		profile := os.Getenv("AWS_PROFILE")
 		envs := os.Environ()
 
-		creds, err := token.GetCredentials(ctx, profile)
+		creds, err := token.GetCredentials(ctx,
+			token.Profile(profile),
+			token.Duration(duration),
+			token.SerialNumber(sNum),
+			token.TokenCode(tokenCode))
 		if err != nil {
 			cmd.PrintErrln(err)
 			os.Exit(1)
@@ -76,4 +85,9 @@ func Execute() {
 	}
 }
 
-func init() {}
+func init() {
+	rootCmd.Flags().StringVarP(&profile, "profile", "p", "", "AWS profile")
+	rootCmd.Flags().StringVarP(&duration, "duration", "d", "12hours", "the duration that the credentials should remain valid")
+	rootCmd.Flags().StringVarP(&sNum, "serial-number", "n", "", "the identification number of the MFA device")
+	rootCmd.Flags().StringVarP(&tokenCode, "token-code", "c", "", "the value provided by the MFA device")
+}

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.14
 require (
 	github.com/Songmu/prompter v0.4.0
 	github.com/aws/aws-sdk-go v1.35.12
+	github.com/k1LoW/duration v1.1.0
 	github.com/spf13/cobra v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/k1LoW/duration v1.1.0 h1:KEIL/aAGL//DnGMCiMrxSgRcVw4nM0ur6KSC9kEBsDo=
+github.com/k1LoW/duration v1.1.0/go.mod h1:MEWYmZ4Agei4RDvERiInjZAhcZStYLp6y7+ZrpaAMJQ=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
```console
$ awsdo -h
AWS temporary credential (aka session token) wrapper.

Usage:
  awsdo [flags]

Flags:
  -d, --duration string        the duration that the credentials should remain valid (default "12hours")
  -h, --help                   help for awsdo
  -p, --profile string         AWS profile
  -n, --serial-number string   the identification number of the MFA device
  -c, --token-code string      the value provided by the MFA device
  -v, --version                version for awsdo
```