### PR TITLE
Add support for the envvars AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE

### DIFF
--- a/ini/ini.go
+++ b/ini/ini.go
@@ -41,7 +41,11 @@ func New() (*Ini, error) {
 	if configIniPath == "" {
 		configIniPath = filepath.Join(home, ".aws", "config")
 	}
-	credsIniPath := filepath.Join(home, ".aws", "credentials")
+
+	credsIniPath := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	if credsIniPath == "" {
+		credsIniPath = filepath.Join(home, ".aws", "credentials")
+	}
 
 	configIni, err := ini.Load(configIniPath)
 	if err != nil {

--- a/ini/ini.go
+++ b/ini/ini.go
@@ -36,7 +36,11 @@ func New() (*Ini, error) {
 	if err != nil {
 		return nil, err
 	}
-	configIniPath := filepath.Join(home, ".aws", "config")
+
+	configIniPath := os.Getenv("AWS_CONFIG_FILE")
+	if configIniPath == "" {
+		configIniPath = filepath.Join(home, ".aws", "config")
+	}
 	credsIniPath := filepath.Join(home, ".aws", "credentials")
 
 	configIni, err := ini.Load(configIniPath)


### PR DESCRIPTION
Hi! Thank you for a useful tool 😆 

I would like to suggest that this excellent tool respects the individual settings of the user regarding the location of the AWS CLI configuration file, [AWS_CONFIG_FILE](https://github.com/awsdocs/aws-cli-user-guide/blob/a7a3359f8f52e7665edad075dd2ccb8b0d7c8b1c/doc_source/cli-configure-envvars.md#L72-L74) and [AWS_SHARED_CREDENTIALS_FILE](https://github.com/awsdocs/aws-cli-user-guide/blob/a7a3359f8f52e7665edad075dd2ccb8b0d7c8b1c/doc_source/cli-configure-envvars.md#L113-L115).

Please check my changes and merge them if you like it. Thanks!