### PR TITLE
Add option `--role-arn` and `--source-profile` for Assuming Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,15 @@ $ eval "$(awsdo --profile myaws --token-code 123456)"
 - Load `~/.aws/credentials` and `~/.aws/config`.
 - Find profile ( section of `AWS_PROFILE` or `--profile` ).
 - Get temporary credentials.
-    1. If the section has `role_arn`, `awsdo` tries to assume role ( `sts:AssumeRole` ).
+    1. If `--role-arn` is set, `awsdo` tries to assume role ( `sts:AssumeRole` ).
+        - `awsdo` tries to get the MFA device serial number ( `iam:ListMFADevices` ).
+        - If `awsdo` get MFA device serial number, it uses multi-factor authentication.
+        - Get temporary credentials.
+    2. If the section has `role_arn`, `awsdo` tries to assume role ( `sts:AssumeRole` ).
         - If the section does not have `mfa_serial`, `awsdo` tries to get the MFA device serial number ( `iam:ListMFADevices` ).
         - If `awsdo` get MFA device serial number, it uses multi-factor authentication.
         - Get temporary credentials.
-    2. Else, `awsdo` try to get session token ( `sts:getSessionToken` ).
+    3. Else, `awsdo` try to get session token ( `sts:getSessionToken` ).
         - If the section does not have `mfa_serial`, `awsdo` tries to get the MFA device serial number ( `iam:ListMFADevices` ).
         - If `awsdo` get MFA device serial number, it uses multi-factor authentication.
         - Get temporary credentials.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,11 +33,13 @@ import (
 )
 
 var (
-	profile      string
-	duration     string
-	sNum         string
-	tokenCode    string
-	disableCache bool
+	profile       string
+	roleArn       string
+	sourceProfile string
+	duration      string
+	sNum          string
+	tokenCode     string
+	disableCache  bool
 )
 
 var rootCmd = &cobra.Command{
@@ -52,6 +54,8 @@ var rootCmd = &cobra.Command{
 
 		t, err := token.Get(ctx,
 			token.Profile(profile),
+			token.RoleArn(roleArn),
+			token.SourceProfile(sourceProfile),
 			token.Duration(duration),
 			token.SerialNumber(sNum),
 			token.TokenCode(tokenCode),
@@ -99,6 +103,8 @@ func Execute() {
 
 func init() {
 	rootCmd.Flags().StringVarP(&profile, "profile", "p", "", "AWS named profile")
+	rootCmd.Flags().StringVarP(&roleArn, "role-arn", "r", "", "IAM Role ARN to be assumed")
+	rootCmd.Flags().StringVarP(&sourceProfile, "source-profile", "s", "", "AWS named profile that assume role")
 	rootCmd.Flags().StringVarP(&duration, "duration", "d", "1hour", "the duration that the credentials should remain valid")
 	rootCmd.Flags().StringVarP(&sNum, "serial-number", "n", "", "the identification number of the MFA device")
 	rootCmd.Flags().StringVarP(&tokenCode, "token-code", "c", "", "the value provided by the MFA device")


### PR DESCRIPTION
Can be executed without profile setting of assumed role.

```console
$ awsdo --role-arn=arn:aws:iam::NNNNNNNNNNNN:role/ExecutionRole --source-profile=myaws -- aws s3 ls
```