### PR TITLE
fix: fix ini handling

### DIFF
--- a/ini/ini.go
+++ b/ini/ini.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"gopkg.in/ini.v1"
 )
@@ -24,8 +23,6 @@ func (i *Ini) GetKey(profile, key string) string {
 		return i.configIni.Section(profile).Key(key).String()
 	case i.configIni.Section(fmt.Sprintf("profile %s", profile)).Key(key).String() != "":
 		return i.configIni.Section(fmt.Sprintf("profile %s", profile)).Key(key).String()
-	case strings.HasPrefix(key, "sso_") && i.configIni.Section(fmt.Sprintf("sso-session %s", profile)).Key(key).String() != "":
-		return i.configIni.Section(fmt.Sprintf("sso-session %s", profile)).Key(key).String()
 	case i.credsIni.Section("default").Key(key).String() != "":
 		return i.credsIni.Section("default").Key(key).String()
 	case i.configIni.Section("default").Key(key).String() != "":


### PR DESCRIPTION
This pull request includes significant updates to the `ssoLogin` function in the `auth/auth.go` file to improve the handling of SSO profile attributes. Additionally, there is a minor cleanup in the `ini/ini.go` file to remove an unused import and simplify the `GetKey` function.

### Improvements to `ssoLogin` function in `auth/auth.go`:

* Simplified the profile validation logic by removing redundant checks for `sso_start_url`, `sso_region`, and `sso_registration_scopes` and adding fallback mechanisms to retrieve these values from the `sso-session` section if they are not present in the profile.
* Added error handling to return an error if any of the required SSO attributes (`sso_start_url`, `sso_region`, `sso_registration_scopes`) are missing after the fallback mechanism.
* Updated the `StartUrl` parameter in the `StartDeviceAuthorization` call to use the retrieved `ssoStartURL` variable instead of directly accessing the profile key.
* Modified the caching logic to use the retrieved `ssoSession` variable for constructing the cache path.

### Code cleanup in `ini/ini.go`:

* Removed the unused `strings` import to clean up the code.
* Simplified the `GetKey` function by removing the redundant case for SSO keys, as this logic is now handled within the `ssoLogin` function.