### PR TITLE
fix: Use XDG_STATE_HOME instead of XDG_DATA_HOME

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -494,8 +494,8 @@ func ssoLogin(ctx context.Context, profile string, i *ini.Ini, disableCache bool
 }
 
 func saveSessionTokenAsCache(key string, creds *types.Credentials) error {
-	if _, err := os.Stat(dataPath()); err != nil {
-		if err := os.MkdirAll(dataPath(), 0700); err != nil {
+	if _, err := os.Stat(statePath()); err != nil {
+		if err := os.MkdirAll(statePath(), 0700); err != nil {
 			return err
 		}
 	}
@@ -536,14 +536,14 @@ func getSessionTokenFromCache(key string) (*types.Credentials, error) {
 
 func cachePath(key string) string {
 	r := strings.NewReplacer(":", "_", "/", "_")
-	return filepath.Join(dataPath(), fmt.Sprintf("%s.json", r.Replace(key)))
+	return filepath.Join(statePath(), fmt.Sprintf("%s.json", r.Replace(key)))
 }
 
-func dataPath() string {
-	p := os.Getenv("XDG_DATA_HOME")
+func statePath() string {
+	p := os.Getenv("XDG_STATE_HOME")
 	if p == "" {
 		home, _ := os.UserHomeDir()
-		p = filepath.Join(home, ".local", "share")
+		p = filepath.Join(home, ".local", "state")
 	}
 	return filepath.Join(p, "awsdo")
 }


### PR DESCRIPTION
This pull request updates the session token caching logic in `auth/auth.go` to use the XDG state directory instead of the XDG data directory, aligning with best practices for storing stateful application data.

**Session token caching directory update:**

* Changed all references from `dataPath()` (using `XDG_DATA_HOME` or `~/.local/share`) to `statePath()` (using `XDG_STATE_HOME` or `~/.local/state`) for storing cached session tokens. (`saveSessionTokenAsCache`, `cachePath`, and related helper functions) [[1]](diffhunk://#diff-f5c9a39fac1719f2a73593994b931d8a874449548e8a3753e1be46e761e503eaL497-R498) [[2]](diffhunk://#diff-f5c9a39fac1719f2a73593994b931d8a874449548e8a3753e1be46e761e503eaL539-R546)
* Renamed the helper function from `dataPath()` to `statePath()` and updated its logic to use the appropriate environment variable and default path.